### PR TITLE
fix(name): strip embedded links in TOC

### DIFF
--- a/lua/mtoc/toc.lua
+++ b/lua/mtoc/toc.lua
@@ -147,6 +147,10 @@ function M.gen_toc_list(start_from)
 
     marker_index = (marker_index - 1) % #markers + 1
     local marker = markers[marker_index]
+
+    -- Strip embedded links in TOC: both in name and link.
+    name = name:gsub("%[(.-)%]%(.-%)", "%1")
+
     local link = M.link_formatters.gfm(all_heading_links, name)
     local fmt_info = {
       name = name,


### PR DESCRIPTION
This change is not compatible with complicated heading patterns, but it should work in most cases.