### PR TITLE
handle obsidian style header

### DIFF
--- a/lua/mtoc/config.lua
+++ b/lua/mtoc/config.lua
@@ -9,7 +9,6 @@ M.defaults = {
     -- Either list of lua patterns,
     -- or a function that returns boolean (true means to EXCLUDE heading)
     exclude = {},
-    pattern = "^(#+)%s+(.+)$",
   },
 
   -- Config relating to the style and format of the ToC

--- a/lua/mtoc/toc.lua
+++ b/lua/mtoc/toc.lua
@@ -98,6 +98,17 @@ function M.find_fences(fstart, fend)
   return _find_fences_same(fstart, lines)
 end
 
+local function extract_heading(line)
+	local prefix, name = string.match(line, "^(#+)%s+%[%[(.-)%]%]$") -- Try to match the brackets first
+
+	-- If brackets do not exist, fallback to matching without them
+	if not name then
+		prefix, name = string.match(line, "^(#+)%s+(.+)$")
+	end
+
+	return prefix, name -- Return the prefix and name
+end
+
 ---Returns a list of strings representing the lines of the ToC list.
 ---Calls both link formatter and item formatter based on config.
 ---@param start_from integer|nil The line number before which, headings will be ignored
@@ -133,7 +144,7 @@ function M.gen_toc_list(start_from)
       goto nextline
     end
 
-    local prefix, name = string.match(line, config.opts.headings.pattern)
+    local prefix, name = extract_heading(line)
     if not prefix or not name or #prefix > 6 then
       goto nextline
     end

--- a/lua/mtoc/types/mtoc.lua
+++ b/lua/mtoc/types/mtoc.lua
@@ -7,12 +7,10 @@
 ---@class mtoc.ConfigHeadings
 ---@field before_toc boolean
 ---@field exclude string[]|fun(heading:string):boolean
----@field pattern string
 
 ---@class mtoc.UserConfigHeadings
 ---@field before_toc? boolean
 ---@field exclude? string|string[]|fun(heading:string):boolean
----@field pattern? string
 
 ---@class mtoc.ConfigTocList
 ---@field markers string[]
@@ -43,12 +41,10 @@
 ---@class mtoc.ConfigAutoUpdate
 ---@field enabled boolean
 ---@field events string[]
----@field pattern string
 
 ---@class mtoc.UserConfigAutoUpdate
 ---@field enabled? boolean
 ---@field events? string[]
----@field pattern? string
 
 ---@class mtoc.Config
 ---@field headings mtoc.ConfigHeadings


### PR DESCRIPTION
```
function extract_heading(line)
  local prefix, name = string.match(line, "^(#+)%s+%[%[(.-)%]%]$") -- Try to match the brackets first

  -- If brackets do not exist, fallback to matching without them
  if not name then
    prefix, name = string.match(line, "^(#+)%s+(.+)$")
  end

  return prefix, name -- Return the prefix and name
end

-- Example usage:
local line1 = "# Heading 1"
local prefix1, name1 = extract_heading(line1)
vim.print(name1) -- Output: Heading 1

local line2 = "## [[Heading 2]]"
local prefix2, name2 = extract_heading(line2)
vim.print(name2) -- Output: Heading 2
```

I don't know how to write a single pattern to handle both the normal header style and the obsidian style header.
So I just change the method to extract the header by a regex pattern to this function