### PR TITLE
feat: Add option 'toc_list.padding_lines'

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,13 @@ These shortcuts are shown in `[square brackets]` below.
       end)
       return s
     end,
+
+    -- Called after an array of lines for the ToC is computed. This does not
+    -- include the fences even if it's enabled.
+    post_processor = function(lines) return lines end,
+
+    -- Add padding (blank lines) before and after the TOC
+    padding_lines = 1,
   },
 
   -- Table or boolean. Set to true to use these defaults, set to false to disable completely.

--- a/lua/mtoc/config.lua
+++ b/lua/mtoc/config.lua
@@ -49,7 +49,10 @@ M.defaults = {
 
     -- Called after an array of lines for the ToC is computed. This does not
     -- include the fences even if it's enabled.
-    post_processor = function(lines) return lines end
+    post_processor = function(lines) return lines end,
+
+    -- Add padding (blank lines) before and after the TOC
+    padding_lines = 1,
   },
 
   -- Table or boolean. Set to true to use these defaults, set to false to disable completely.

--- a/lua/mtoc/init.lua
+++ b/lua/mtoc/init.lua
@@ -49,9 +49,14 @@ local function insert_toc(opts)
     lines = config.opts.toc_list.post_processor(lines)
 
     if use_fence then
-      table.insert(lines, 1, '')
+      local pad = config.opts.toc_list.padding_lines
+      for _ = 1, pad do
+        table.insert(lines, 1, '')
+      end
       table.insert(lines, 1, fmt_fence_start(fences.start_text))
-      table.insert(lines, '')
+      for _ = 1, pad do
+        table.insert(lines, '')
+      end
       table.insert(lines, fmt_fence_end(fences.end_text))
     end
   end

--- a/lua/mtoc/types/mtoc.lua
+++ b/lua/mtoc/types/mtoc.lua
@@ -21,6 +21,7 @@
 ---@field item_format_string string
 ---@field item_formatter fun(item_info:mtoc.TocItemInfo, fmtstr:string):string
 ---@field post_processor fun(lines:string[]):string[]
+---@field padding_lines integer
 
 ---@class mtoc.UserConfigTocList
 ---@field markers? string|string[]
@@ -29,6 +30,7 @@
 ---@field item_format_string? string
 ---@field item_formatter? fun(item_info:mtoc.TocItemInfo, fmtstr:string):string
 ---@field post_processor? fun(lines:string[]):string[]
+---@field padding_lines? integer
 
 ---@class mtoc.ConfigFences
 ---@field enabled boolean


### PR DESCRIPTION
### This is a small visual tweak.

- Add `toc_list.padding_lines` to control blank lines before and after the TOC
- Set to 0 to disable padding (default = 1)
- Default behavior remains unchanged if not set

#### Example: padding_lines = 1 (default)
```
<!-- mtoc-start -->

[link](#link)

<!-- mtoc-end -->
```

#### Example: padding_lines = 0
```
<!-- mtoc-start -->
[link](#link)
<!-- mtoc-end -->
```

#### Background:
In my setup, HTML comments like `<!-- -->` are concealed in markdown,
so I wanted to remove the extra blank lines before and after the TOC.

Hope it helps others !