### PR TITLE
style: Add .stylua.toml

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,8 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferDouble"
+syntax = "LuaJIT"
+collapse_simple_statement = "Always"
+

--- a/lua/mtoc/config.lua
+++ b/lua/mtoc/config.lua
@@ -18,7 +18,7 @@ M.defaults = {
     -- If cycle_markers = false and markers is a list, only the first is used.
     -- You can set to '1.' to use a automatically numbered list for ToC (if
     -- your markdown render supports it).
-    markers = { '*' },
+    markers = { "*" },
     cycle_markers = false,
     -- Example config for cycling markers:
     ----- markers = {'*', '+', '-'},
@@ -41,9 +41,7 @@ M.defaults = {
     ---@param fmtstr string from `item_format_string` config
     ---@return string formatted_item
     item_formatter = function(item_info, fmtstr)
-      local s = fmtstr:gsub([[${(%w-)}]], function(key)
-        return item_info[key] or ('${'..key..'}')
-      end)
+      local s = fmtstr:gsub([[${(%w-)}]], function(key) return item_info[key] or ("${" .. key .. "}") end)
       return s
     end,
 
@@ -62,7 +60,7 @@ M.defaults = {
     -- These fence texts are wrapped within "<!-- % -->", where the '%' is
     -- substituted with the text.
     start_text = "mtoc-start",
-    end_text = "mtoc-end"
+    end_text = "mtoc-end",
     -- An empty line is inserted on top and below the ToC list before the being
     -- wrapped with the fence texts, same as vim-markdown-toc.
   },
@@ -94,30 +92,26 @@ M.opts = M.defaults
 function M.resolve_shortcut_opts()
   ---@type any
   local value = M.opts.fences
-  if type(value) == 'boolean' then
+  if type(value) == "boolean" then
     M.opts.fences = M.defaults.fences
-    if not value then
-      M.opts.fences.enabled = false
-    end
+    if not value then M.opts.fences.enabled = false end
   end
 
   value = M.opts.auto_update
-  if type(value) == 'boolean' then
+  if type(value) == "boolean" then
     M.opts.auto_update = M.defaults.auto_update
-    if not value then
-      M.opts.auto_update.enabled = false
-    end
+    if not value then M.opts.auto_update.enabled = false end
   end
 
-  if type(M.opts.auto_update.events) == 'string' then
+  if type(M.opts.auto_update.events) == "string" then
     ---@diagnostic disable-next-line
     M.opts.auto_update.events = { M.opts.auto_update.events }
   end
-  if type(M.opts.toc_list.markers) == 'string' then
+  if type(M.opts.toc_list.markers) == "string" then
     ---@diagnostic disable-next-line
     M.opts.toc_list.markers = { M.opts.toc_list.markers }
   end
-  if type(M.opts.headings.exclude) == 'string' then
+  if type(M.opts.headings.exclude) == "string" then
     ---@diagnostic disable-next-line
     M.opts.headings.exclude = { M.opts.headings.exclude }
   end
@@ -125,13 +119,13 @@ end
 
 ---@param opts mtoc.UserConfig
 function M.merge_opts(opts)
-  M.opts = vim.tbl_deep_extend('force', {}, M.defaults, opts or {})
+  M.opts = vim.tbl_deep_extend("force", {}, M.defaults, opts or {})
   M.resolve_shortcut_opts()
 end
 
 ---@param opts mtoc.UserConfig
 function M.update_opts(opts)
-  M.opts = vim.tbl_deep_extend('force', {}, M.opts, opts or {})
+  M.opts = vim.tbl_deep_extend("force", {}, M.opts, opts or {})
   M.resolve_shortcut_opts()
 end
 

--- a/lua/mtoc/init.lua
+++ b/lua/mtoc/init.lua
@@ -1,33 +1,27 @@
-local toc = require('mtoc/toc')
-local config = require('mtoc/config')
-local utils = require('mtoc/utils')
+local toc = require("mtoc/toc")
+local config = require("mtoc/config")
+local utils = require("mtoc/utils")
 
 local empty_or_nil = utils.empty_or_nil
 local falsey = utils.falsey
 
 local M = {}
-M.commands = {'insert', 'update', 'remove'}
+M.commands = { "insert", "update", "remove" }
 
-local function fmt_fence_start(fence) return '<!-- '..fence..' -->' end
-local function fmt_fence_end(fence) return '<!-- '..fence..' -->' end
+local function fmt_fence_start(fence) return "<!-- " .. fence .. " -->" end
+local function fmt_fence_end(fence) return "<!-- " .. fence .. " -->" end
 
 local function get_fences()
   local fences = config.opts.fences
-  if type(fences) == 'boolean' and fences then
-    fences = config.defaults.fences
-  end
+  if type(fences) == "boolean" and fences then fences = config.defaults.fences end
   return fences
 end
 
 local function insert_toc(opts)
-  if not opts then
-    opts = {}
-  end
+  if not opts then opts = {} end
 
   local start = opts.line or utils.current_line()
-  if config.opts.headings.before_toc then
-    start = 0
-  end
+  if config.opts.headings.before_toc then start = 0 end
 
   local lines = {}
   local fences = get_fences()
@@ -38,7 +32,7 @@ local function insert_toc(opts)
     if use_fence then
       lines = {
         fmt_fence_start(fences.start_text),
-        '',
+        "",
         fmt_fence_end(fences.end_text),
       }
     else
@@ -51,11 +45,11 @@ local function insert_toc(opts)
     if use_fence then
       local pad = config.opts.toc_list.padding_lines
       for _ = 1, pad do
-        table.insert(lines, 1, '')
+        table.insert(lines, 1, "")
       end
       table.insert(lines, 1, fmt_fence_start(fences.start_text))
       for _ = 1, pad do
-        table.insert(lines, '')
+        table.insert(lines, "")
       end
       table.insert(lines, fmt_fence_end(fences.end_text))
     end
@@ -70,9 +64,7 @@ local function remove_toc(not_found_ok)
 
   local locations = toc.find_fences(fstart, fend)
   if empty_or_nil(locations) or (falsey(locations.start) and falsey(locations.end_)) then
-    if not not_found_ok then
-      vim.notify("No fences found!", vim.log.levels.ERROR)
-    end
+    if not not_found_ok then vim.notify("No fences found!", vim.log.levels.ERROR) end
     return
   end
   if locations.start and falsey(locations.end_) then
@@ -97,21 +89,17 @@ local function update_toc(opts, fail_ok)
   if opts.range_start and opts.range_end then
     utils.delete_lines(opts.range_start, opts.range_end)
     local use_fence = opts.bang
-    return insert_toc({ line = opts.range_start-1, disable_fence = not use_fence })
+    return insert_toc({ line = opts.range_start - 1, disable_fence = not use_fence })
   end
 
   local locations = remove_toc(fail_ok)
-  if empty_or_nil(locations) then
-    return
-  end
-  opts.line = locations.start-1
+  if empty_or_nil(locations) then return end
+  opts.line = locations.start - 1
   return insert_toc(opts)
 end
 
 local function update_or_remove_toc(opts)
-  if opts.range_start and opts.range_end then
-    return update_toc(opts)
-  end
+  if opts.range_start and opts.range_end then return update_toc(opts) end
 
   local locations = remove_toc(true)
   opts = opts or {}
@@ -119,7 +107,7 @@ local function update_or_remove_toc(opts)
     opts.line = nil
     return insert_toc(opts)
   end
-  opts.line = locations.start-1
+  opts.line = locations.start - 1
   return insert_toc(opts)
 end
 
@@ -136,23 +124,18 @@ local function handle_command(opts)
     fnopts.range_end = opts.line2
   end
 
-  if empty_or_nil(opts.fargs) then
-    return update_or_remove_toc(fnopts)
-  end
+  if empty_or_nil(opts.fargs) then return update_or_remove_toc(fnopts) end
 
   local cmd = opts.fargs[1]
-  if cmd == 'debug' then
-    return _debug_show_headings()
-  end
-  if cmd:sub(#cmd, #cmd) == '!' then
+  if cmd == "debug" then return _debug_show_headings() end
+  if cmd:sub(#cmd, #cmd) == "!" then
     fnopts.bang = true
-    cmd = cmd:sub(1, #cmd-1)
+    cmd = cmd:sub(1, #cmd - 1)
   end
-
 
   local found = false
   for _, v in ipairs(M.commands) do
-    if string.match(v, "^"..cmd) then
+    if string.match(v, "^" .. cmd) then
       cmd = v
       found = true
       break
@@ -160,7 +143,7 @@ local function handle_command(opts)
   end
 
   if not found then
-    vim.notify("Unknown command "..cmd, vim.log.levels.ERROR)
+    vim.notify("Unknown command " .. cmd, vim.log.levels.ERROR)
     return
   end
 
@@ -171,18 +154,16 @@ local function handle_command(opts)
   elseif cmd == "remove" then
     return remove_toc()
   else
-    vim.notify("INTERNAL ERROR: Unhandled command "..cmd, vim.log.levels.ERROR)
+    vim.notify("INTERNAL ERROR: Unhandled command " .. cmd, vim.log.levels.ERROR)
   end
 end
 
 local function setup_commands()
   vim.api.nvim_create_user_command("Mtoc", handle_command, {
-    nargs = '?',
+    nargs = "?",
     range = true,
     bang = true,
-    complete = function()
-      return M.commands
-    end,
+    complete = function() return M.commands end,
   })
 end
 
@@ -190,12 +171,10 @@ local function setup_autocmds()
   M.autocmds = {}
   if config.opts.auto_update then
     local aup = config.opts.auto_update
-    if type(aup) == 'boolean' then
-      aup = config.defaults.auto_update
-    end
+    if type(aup) == "boolean" then aup = config.defaults.auto_update end
     local id = vim.api.nvim_create_autocmd(aup.events, {
       pattern = aup.pattern,
-      callback = function() update_toc({}, true) end
+      callback = function() update_toc({}, true) end,
     })
     table.insert(M, id)
   end
@@ -203,9 +182,7 @@ end
 
 ---Remove autocmds that were set up by this plugin
 function M.remove_autocmds()
-  if empty_or_nil(M.autocmds) then
-    return
-  end
+  if empty_or_nil(M.autocmds) then return end
   for _, id in ipairs(M.autocmds) do
     vim.api.nvim_del_autocmd(id)
   end

--- a/lua/mtoc/toc.lua
+++ b/lua/mtoc/toc.lua
@@ -1,8 +1,7 @@
-local config = require('mtoc/config')
+local config = require("mtoc/config")
 
 local M = {}
 M.link_formatters = {}
-
 
 ---Link formatter based on GitHub Flavoured Markdown
 ---@param existing_headings { [string]: number }
@@ -15,7 +14,12 @@ function M.link_formatters.gfm(existing_headings, heading)
 
   -- Strip non-alphanumric non-latin-extended, and non-CJK characters.
   -- Lua doesn't handle unicode very well.
-  heading = vim.fn.substitute(heading, [[[^[:alnum:]\u00C0-\u00FF\u0400-\u04ff\u4e00-\u9fbf\u3040-\u309F\u30A0-\u30FF\uAC00-\uD7AF _-]].."]", "", "g")
+  heading = vim.fn.substitute(
+    heading,
+    [[[^[:alnum:]\u00C0-\u00FF\u0400-\u04ff\u4e00-\u9fbf\u3040-\u309F\u30A0-\u30FF\uAC00-\uD7AF _-]] .. "]",
+    "",
+    "g"
+  )
 
   -- Convert all spaces to dashes
   heading = heading:gsub(" ", "-")
@@ -23,13 +27,11 @@ function M.link_formatters.gfm(existing_headings, heading)
   local key = heading
   local heading_str = heading
 
-  if heading_str == "" then
-    key = "<NULL>"
-  end
+  if heading_str == "" then key = "<NULL>" end
 
   if existing_headings[key] ~= nil then
     existing_headings[key] = existing_headings[key] + 1
-    heading_str = heading_str .. '-' .. existing_headings[key]
+    heading_str = heading_str .. "-" .. existing_headings[key]
   else
     existing_headings[key] = 0
   end
@@ -42,20 +44,14 @@ local function _find_fences(fstart, fend, lines)
   local locations = {}
   local in_code = false
   for i, line in ipairs(lines) do
-    if locations.start and locations.end_ then
-      break
-    end
+    if locations.start and locations.end_ then break end
 
-    if string.find(line, '^```') then
+    if string.find(line, "^```") then
       in_code = not in_code
     else
       if not in_code then
-        if string.find(line, fstart, 1, true) then
-          locations.start = i
-        end
-        if string.find(line, fend, 1, true) then
-          locations.end_ = i
-        end
+        if string.find(line, fstart, 1, true) then locations.start = i end
+        if string.find(line, fend, 1, true) then locations.end_ = i end
       end
     end
   end
@@ -68,7 +64,7 @@ local function _find_fences_same(fence, lines)
   local in_code = false
   local locations = {}
   for i, line in ipairs(lines) do
-    if string.find(line, '^```') then
+    if string.find(line, "^```") then
       in_code = not in_code
     else
       if not in_code then
@@ -92,9 +88,7 @@ end
 ---@return table locations `{ start = start_lineno, end_ = end_lineno }`
 function M.find_fences(fstart, fend)
   local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-  if fstart ~= fend then
-    return _find_fences(fstart, fend, lines)
-  end
+  if fstart ~= fend then return _find_fences(fstart, fend, lines) end
   return _find_fences_same(fstart, lines)
 end
 
@@ -109,14 +103,10 @@ function M.gen_toc_list(start_from)
   ---@type string|string[]
   local markers = toc_config.markers
   local marker_index = 1
-  if not toc_config.cycle_markers then
-    markers = { markers[1] }
-  end
+  if not toc_config.cycle_markers then markers = { markers[1] } end
 
   local indent_size = toc_config.indent_size
-  if type(indent_size) == 'function' then
-    indent_size = indent_size()
-  end
+  if type(indent_size) == "function" then indent_size = indent_size() end
 
   local item_formatter = toc_config.item_formatter
 
@@ -129,23 +119,15 @@ function M.gen_toc_list(start_from)
   local headings = {}
 
   for _, line in ipairs(vim.api.nvim_buf_get_lines(0, start_from, -1, false)) do
-    if string.find(line, '^```') then
-      is_inside_code_block = not is_inside_code_block
-    end
-    if is_inside_code_block then
-      goto nextline
-    end
+    if string.find(line, "^```") then is_inside_code_block = not is_inside_code_block end
+    if is_inside_code_block then goto nextline end
 
     local prefix, name = string.match(line, config.opts.headings.pattern)
-    if not prefix or not name or #prefix > 6 then
-      goto nextline
-    end
+    if not prefix or not name or #prefix > 6 then goto nextline end
 
     local depth = #prefix
 
-    if prev_depth + 1 < depth then
-      depth = prev_depth + 1
-    end
+    if prev_depth + 1 < depth then depth = prev_depth + 1 end
     prev_depth = depth
 
     marker_index = (marker_index - 1) % #markers + 1
@@ -165,9 +147,7 @@ function M.gen_toc_list(start_from)
       raw_line = line,
     }
 
-    if depth < min_depth then
-      min_depth = depth
-    end
+    if depth < min_depth then min_depth = depth end
     table.insert(headings, fmt_info)
     ::nextline::
   end

--- a/lua/mtoc/utils.lua
+++ b/lua/mtoc/utils.lua
@@ -3,46 +3,36 @@ local M = {}
 ---Delete lines in current buffer with inclusive line ranges
 ---@param s integer Line number of start (inclusive)
 ---@param e integer Line number of end (inclusive)
-function M.delete_lines(s, e)
-  vim.api.nvim_buf_set_lines(0, s-1, e, true, {})
-end
+function M.delete_lines(s, e) vim.api.nvim_buf_set_lines(0, s - 1, e, true, {}) end
 
 ---Convenience function for inserting lines at line
 ---@param line integer Line number of where to insert
 ---@param lines string[] Lines to insert
-function M.insert_lines(line, lines)
-  vim.api.nvim_buf_set_lines(0, line, line, true, lines)
-end
+function M.insert_lines(line, lines) vim.api.nvim_buf_set_lines(0, line, line, true, lines) end
 
 ---Convenience function to get current line number in current buffer
 ---@return integer current_lineno
-function M.current_line()
-  return vim.api.nvim_win_get_cursor(0)[1]
-end
+function M.current_line() return vim.api.nvim_win_get_cursor(0)[1] end
 
 ---Return whether tbl is either empty or nil
 ---@param tbl table|nil
 ---@return boolean emtpy_or_nil True means tbl ~= nil and tbl ~= {}
-function M.empty_or_nil(tbl)
-  return not tbl or next(tbl) == nil
-end
+function M.empty_or_nil(tbl) return not tbl or next(tbl) == nil end
 
 ---Returns true for empty strings, number 0, nil or empty tables
 ---@param obj any
 ---@return boolean
 function M.falsey(obj)
-  if type(obj) == 'table' then
+  if type(obj) == "table" then
     return M.empty_or_nil(obj)
-  elseif type(obj) == 'string' then
-    return obj == ''
-  elseif type(obj) == 'number' then
+  elseif type(obj) == "string" then
+    return obj == ""
+  elseif type(obj) == "number" then
     return obj == 0
   end
   return not obj
 end
 
-function M.truthy(obj)
-  return not M.falsey(obj)
-end
+function M.truthy(obj) return not M.falsey(obj) end
 
 return M


### PR DESCRIPTION
This fixes various formatting inconsistencies (e.g., '' vs "", collapsed vs multi-line blocks) by applying stylua.  
~~*.lua files are left untouched.~~ -> formatted now.

I tried to match the current style as closely as possible, but there was too much variation to make it perfect.

Please feel free to ignore this if its' not needed.